### PR TITLE
luci-mod-admin-full: optimize acquisition of cpu idle

### DIFF
--- a/modules/luci-mod-admin-full/luasrc/view/admin_status/index.htm
+++ b/modules/luci-mod-admin-full/luasrc/view/admin_status/index.htm
@@ -54,7 +54,7 @@
 			connmax    = conn_max,
 			conncount  = conn_count,
 			wifinets   = stat.wifi_networks(),
-			cpu_free   = tonumber(luci.sys.exec("echo `top -n 1 | grep CPU | grep -v grep | head -n 1 | awk '{print $8}' | sed 's/\\(.*\\)\\(.\\)$/\\1/'`")),
+			cpu_free   = tonumber(luci.sys.exec("top -n1 | grep -m1 -i 'cpu' | awk '{print $8}' | grep -Eo '[0-9.]+'")),
 		}
 
 		if wan then

--- a/modules/luci-mod-admin-full/luasrc/view/admin_status/index_x86.htm
+++ b/modules/luci-mod-admin-full/luasrc/view/admin_status/index_x86.htm
@@ -60,7 +60,7 @@
 			connmax    = conn_max,
 			conncount  = conn_count,
 			wifinets   = stat.wifi_networks(),
-			cpu_free   = tonumber(luci.sys.exec("echo `top -n 1 | grep CPU | grep -v grep | head -n 1 | awk '{print $8}' | sed 's/\\(.*\\)\\(.\\)$/\\1/'`")),
+			cpu_free   = tonumber(luci.sys.exec("top -n1 | grep -m1 -i 'cpu' | awk '{print $8}' | grep -Eo '[0-9.]+'")),
 		}
 
 		if wan then


### PR DESCRIPTION
更通用的方式去获取 cpu 的空闲值
试了一下，这么写还能在 ubuntu, debain 上跑，当然 openwrt 也是没问题的

貌似还能这么写，其实下面这种写法才能确保获取的是 cpu idle，但是不知道为啥在 ubuntu 上失效了，`id` 就是 `idle`，很多系统只前两字符。
```
top -n1 | grep -m1 -i 'cpu' | grep -Eo '[0-9.]+%? id' | grep -Eo '[0-9.]+'
```