### PR TITLE
[18.06] luci-app-ddns: fix huge typo in luasrc/tools/ddns.lua

### DIFF
--- a/applications/luci-app-ddns/luasrc/tools/ddns.lua
+++ b/applications/luci-app-ddns/luasrc/tools/ddns.lua
@@ -10,121 +10,120 @@ local SYS  = require "luci.sys"
 
 function env_info(type)
 
-	if ( type == "has_ssl" ) or ( type == "has_proxy" ) or ( type == "has_forceip" ) 
-	    or ( type == "has_bindnet" ) or ( type == "has_fetch" ) 
-		or ( type == "has_wgetssl" ) or ( type == "has_curl" ) 
-		or ( type == "has_curlssl" ) or ( type == "has_curlpxy" ) 
-		or ( type == "has_fetchssl" ) or ( type == "has_bbwget" ) then 
-		
-		local function has_wgetssl() 
+	if ( type == "has_ssl" ) or ( type == "has_proxy" ) or ( type == "has_forceip" )
+	    or ( type == "has_bindnet" ) or ( type == "has_fetch" )
+		or ( type == "has_wgetssl" ) or ( type == "has_curl" )
+		or ( type == "has_curlssl" ) or ( type == "has_curlpxy" )
+		or ( type == "has_fetchssl" ) or ( type == "has_bbwget" ) then
+
+		local function has_wgetssl()
 			return (SYS.call( [[which wget-ssl >/dev/null 2>&1]] ) == 0)	-- and true or nil
 		end
-		
-		local function has_curlssl() 
+
+		local function has_curlssl()
 			return (SYS.call( [[$(which curl) -V 2>&1 | grep "Protocols:" | grep -qF "https"]] ) ~= 0)
 		end
-		
+
 		local function has_fetch()
 			return (SYS.call( [[which uclient-fetch >/dev/null 2>&1]] ) == 0)
 		end
-		
+
 		local function has_fetchssl()
 			return NXFS.access("/lib/libustream-ssl.so")
 		end
-		
+
 		local function has_curl()
 			return (SYS.call( [[which curl >/dev/null 2>&1]] ) == 0)
 		end
-		
+
 		local function has_curlpxy()
 			return (SYS.call( [[grep -i "all_proxy" /usr/lib/libcurl.so* >/dev/null 2>&1]] ) == 0)
 		end
-		
+
 		local function has_bbwget()
 			return (SYS.call( [[$(which wget) -V 2>&1 | grep -iqF "busybox"]] ) == 0)
 		end
-		
+
 		if type == "has_wgetssl" then
 			return has_wgetssl()
-		
+
 		elseif type == "has_curl" then
 			return has_curl()
-			
+
 		elseif type == "has_curlssl" then
 			return has_curlssl()
-			
+
 		elseif type == "has_curlpxy" then
 			return has_curlpxy()
-			
+
 		elseif type == "has_fetch" then
 			return has_fetch()
-			
+
 		elseif type == "has_fetchssl" then
 			return has_fetchssl()
-			
+
 		elseif type == "has_bbwget" then
 			return has_bbwget()
-		
+
 		elseif type == "has_ssl" then
 			if has_wgetssl() then return true end
 			if has_curlssl() then return true end
 			if (has_fetch() and has_fetchssl()) then return true end
 			return false
-			
+
 		elseif type == "has_proxy" then
 			if has_wgetssl() then return true end
 			if has_curlpxy() then return true end
 			if has_fetch() then return true end
 			if has_bbwget() then return true end
 			return false
-			
+
 		elseif type == "has_forceip" then
 			if has_wgetssl() then return true end
 			if has_curl() then return true end
 			if has_fetch() then return true end -- only really needed for transfer
 			return false
-			
+
 		elseif type == "has_bindnet" then
 			if has_curl() then return true end
 			if has_wgetssl() then return true end
 			return false
 		end
-	
+
 	elseif ( type == "has_dnsserver" ) or ( type == "has_bindhost" ) or ( type == "has_hostip" ) or ( type == "has_nslookup" ) then
-		local function has_bindhost() 
-			if (SYS.call( [[which host >/dev/null 2>&1]] ) == 0) then return true end
+		local function has_bindhost()
 			if (SYS.call( [[which host >/dev/null 2>&1]] ) == 0) then return true end
 			if (SYS.call( [[which khost >/dev/null 2>&1]] ) == 0) then return true end
 			if (SYS.call( [[which drill >/dev/null 2>&1]] ) == 0) then return true end
 			return false
 		end
-		
+
 		local function has_hostip()
 			return (SYS.call( [[which hostip >/dev/null 2>&1]] ) == 0)
 		end
-		
+
 		local function has_nslookup()
 			return (SYS.call( [[$(which nslookup) localhost 2>&1 | grep -qF "(null)"]] ) ~= 0)
 		end
-		
+
 		if type == "has_bindhost" then
 			return has_bindhost()
 		elseif type == "has_hostip" then
 			return has_hostip()
 		elseif type == "has_nslookup" then
 			return has_nslookup()
-		elseif tyep == "has_dnsserver" then
+		elseif type == "has_dnsserver" then
 			if has_bindhost() then return true end
 			if has_hostip() then return true end
 			if has_nslookup() then return true end
 			return false
 		end
-		
+
 	elseif type == "has_ipv6" then
 		return (NXFS.access("/proc/net/ipv6_route") and NXFS.access("/usr/sbin/ip6tables"))
-		
+
 	elseif type == "has_cacerts" then
-		--old _check_certs() local function 
+		--old _check_certs() local function
 		local _, v = NXFS.glob("/etc/ssl/certs/*.crt")
 		if ( v == 0 ) then _, v = NXFS.glob("/etc/ssl/certs/*.pem") end
 		return (v > 0)

--- a/applications/luci-app-ddns/luasrc/tools/ddns.lua
+++ b/applications/luci-app-ddns/luasrc/tools/ddns.lua
@@ -21,7 +21,7 @@ function env_info(type)
 		end
 
 		local function has_curlssl()
-			return (SYS.call( [[$(which curl) -V 2>&1 | grep "Protocols:" | grep -qF "https"]] ) ~= 0)
+			return (SYS.call( [[$(which curl) -V 2>&1 | grep "Protocols:" | grep -qF "https"]] ) == 0)
 		end
 
 		local function has_fetch()


### PR DESCRIPTION
装了 bind-host 还有提示，pick 了两 openwrt-19.07 的 commit，应该能修复
```
当前编译版本中 BusyBox 的 nslookup 在处理给定的 DNS 服务器不正确！
- 如果您需要指定 DNS 服务器来检测您注册的 IP，您应该安装“bind-host”或“knot-host”或“drill”或“hostip”软件包。
```