### PR TITLE
修复matrial主题错误时机出现加载条

### DIFF
--- a/themes/luci-theme-material/htdocs/luci-static/material/js/script.js
+++ b/themes/luci-theme-material/htdocs/luci-static/material/js/script.js
@@ -139,8 +139,12 @@
         var onclick = that.attr("onclick");
         if (onclick == undefined || onclick == "") {
             that.click(function () {
+                var target = that.attr("target");
                 var href = that.attr("href");
-                if (href.indexOf("#") == -1) {
+                if ((target == undefined || target == "" || target == "_self")
+                    && href != undefined
+                    && href.indexOf("#") != 0
+                    && href.indexOf("javascript:") != 0) {
                     $(".main > .loading").fadeIn("fast");
                     return true;
                 }


### PR DESCRIPTION
luci官方已经修复了这个bug，
https://github.com/openwrt/luci/commit/e77430d8bb520b7ea588ee9902d59cf963f4db6f#diff-ce82894ddfd18956455a9d9cdb2b2498ee0ffff4134261c51166f368da9957b4

但是官方是直接删除了所有a标签的加载条，我希望保留窗口内跳转到其他页面的加载条