### PR TITLE
luci-theme-argon: fix wrong active state on common prefix nodes

### DIFF
--- a/themes/luci-theme-argon/htdocs/luci-static/argon/js/script.js
+++ b/themes/luci-theme-argon/htdocs/luci-static/argon/js/script.js
@@ -71,7 +71,7 @@ document.addEventListener('luci-loaded', function(ev) {
 				var that = $(this);
 				var href = that.attr("href");
 
-				if (href.indexOf(nodeUrl) != -1) {
+				if (href.endsWith(nodeUrl) || href.indexOf('/' + nodeUrl + '/') != -1) {
 					ulNode.click();
 					ulNode.next(".slide-menu").stop(true, true);
 					lastNode = that.parent();


### PR DESCRIPTION
Before fixed, if we have two nodes: 'services/ddns' and 'services/ddnsto',
click any one of they, will show they all actived.

(this bug comes from luci-theme-material)

跟 luci-theme-material 同样的bug， 但是 luci-theme-material  需要等上游合并PR