### PR TITLE
luci-theme-material: fix style for leaf nodes on top level menu

### DIFF
--- a/themes/luci-theme-material/htdocs/luci-static/material/css/style.css
+++ b/themes/luci-theme-material/htdocs/luci-static/material/css/style.css
@@ -333,6 +333,9 @@ header > .container > .brand {
 
 .main > .main-left > .nav > li:nth-last-child(1) {
     margin-top: 2rem;
+}
+
+.main > .main-left > .nav > li.entry {
     font-size: 1.2rem;
 }
 

--- a/themes/luci-theme-material/luasrc/view/themes/material/header.htm
+++ b/themes/luci-theme-material/luasrc/view/themes/material/header.htm
@@ -144,7 +144,7 @@
 				else
 					local title = pcdata(striptags(translate(nnode.title)))
 
-					write('<li><a data-title="%s" href="%s">%s</a></li>' %{
+					write('<li class="entry"><a data-title="%s" href="%s">%s</a></li>' %{
 						title,
 						nodeurl(category, r, nnode.query),
 						title


### PR DESCRIPTION
修复material主题导航菜单顶层叶子节点与非叶子节点风格不统一的问题

Signed-off-by: jjm2473 <1129525450@qq.com>