### PR TITLE
luci-theme-argon-*: fix wrong active state on common prefix node

### DIFF
--- a/themes/luci-theme-argon-dark-mod/htdocs/luci-static/argon_dark/js/script.js
+++ b/themes/luci-theme-argon-dark-mod/htdocs/luci-static/argon_dark/js/script.js
@@ -82,7 +82,7 @@
                 var that = $(this);
                 var href = that.attr("href");
 
-                if (href.indexOf(nodeUrl) != -1) {
+                if (href.endsWith(nodeUrl) || href.indexOf('/' + nodeUrl + '/') != -1) {
                     ulNode.click();
                     ulNode.next(".slide-menu").stop(true, true);
                     lastNode = that.parent();

--- a/themes/luci-theme-argon-dark-mod/htdocs/luci-static/argon_dark_purple/js/script.js
+++ b/themes/luci-theme-argon-dark-mod/htdocs/luci-static/argon_dark_purple/js/script.js
@@ -82,7 +82,7 @@
                 var that = $(this);
                 var href = that.attr("href");
 
-                if (href.indexOf(nodeUrl) != -1) {
+                if (href.endsWith(nodeUrl) || href.indexOf('/' + nodeUrl + '/') != -1) {
                     ulNode.click();
                     ulNode.next(".slide-menu").stop(true, true);
                     lastNode = that.parent();

--- a/themes/luci-theme-argon-light-mod/htdocs/luci-static/argon_light/js/script.js
+++ b/themes/luci-theme-argon-light-mod/htdocs/luci-static/argon_light/js/script.js
@@ -82,7 +82,7 @@
                 var that = $(this);
                 var href = that.attr("href");
 
-                if (href.indexOf(nodeUrl) != -1) {
+                if (href.endsWith(nodeUrl) || href.indexOf('/' + nodeUrl + '/') != -1) {
                     ulNode.click();
                     ulNode.next(".slide-menu").stop(true, true);
                     lastNode = that.parent();

--- a/themes/luci-theme-argon-light-mod/htdocs/luci-static/argon_light_green/js/script.js
+++ b/themes/luci-theme-argon-light-mod/htdocs/luci-static/argon_light_green/js/script.js
@@ -82,7 +82,7 @@
                 var that = $(this);
                 var href = that.attr("href");
 
-                if (href.indexOf(nodeUrl) != -1) {
+                if (href.endsWith(nodeUrl) || href.indexOf('/' + nodeUrl + '/') != -1) {
                     ulNode.click();
                     ulNode.next(".slide-menu").stop(true, true);
                     lastNode = that.parent();


### PR DESCRIPTION
Before fixed, if we have two nodes: 'services/ddns' and 'services/ddnsto',
click any one of they, will show they all actived.

Signed-off-by: jjm2473 <1129525450@qq.com>

跟这个同样的问题 https://github.com/Lienol/openwrt-luci/pull/7