### PR TITLE
luci-base: fix language auto detection

### DIFF
--- a/modules/luci-base/luasrc/dispatcher.lua
+++ b/modules/luci-base/luasrc/dispatcher.lua
@@ -225,6 +225,11 @@ function dispatch(request)
 				lang = lpat
 				break
 			end
+			lpat = lpat and lpat:lower()
+			if conf.languages[lpat] then
+				lang = lpat
+				break
+			end
 		end
 	end
 	if lang == "auto" then


### PR DESCRIPTION
Chrome send http header "Accept-Language: zh-CN,zh;q=0.9,en;q=0.8", 
we only have "zh_cn" language, that would not match,
we should try lowercase.

修复语言设置成自动时不能按浏览器语言切换的bug：
chrome的请求头包含"Accept-Language: zh-CN,zh;q=0.9,en;q=0.8"，
代码的逻辑无法让“zh-CN”匹配“zh_cn”，尝试用小写再匹配一次。