### PR TITLE
luci-mod-admin-full: fix get partition info by uuid

### DIFF
--- a/modules/luci-mod-admin-full/luasrc/model/cbi/admin_system/fstab.lua
+++ b/modules/luci-mod-admin-full/luasrc/model/cbi/admin_system/fstab.lua
@@ -155,7 +155,7 @@ dev.cfgvalue = function(self, section)
 	local v, e
 
 	v = m.uci:get("fstab", section, "uuid")
-	e = v and devices[v:lower()]
+	e = v and devices[v]
 	if v and e and e.size then
 		return "UUID: %s (%s, %d MB)" %{ tp.pcdata(v), e.dev, e.size }
 	elseif v and e then
@@ -199,7 +199,7 @@ fs.cfgvalue = function(self, section)
 	local v, e
 
 	v = m.uci:get("fstab", section, "uuid")
-	v = v and v:lower() or m.uci:get("fstab", section, "label")
+	v = v or m.uci:get("fstab", section, "label")
 	v = v or m.uci:get("fstab", section, "device")
 
 	e = v and devices[v]


### PR DESCRIPTION
Some filesystems (NTFS,FAT,etc.) always show "not present" in luci "Mount Points",
we should not lowercase uuid

Luci的祖传BUG，但官方已经不维护17版本，就提交到这里吧。

部分文件系统（例如NTFS，FAT等）的UUID不是纯小写的，当挂载点是UUID时，luci界面总会显示这些分区不存在，
代码里不要转小写就行了。

如果18版或者以上的luci也有同样的问题，可以直接cherry-pick过去